### PR TITLE
Added Blocked resource types

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,6 +108,18 @@ app.use('/healthcheck', require('express-healthcheck')());
         }
       }
 
+      // Allow to block certain resource types.
+      // For example: ?blocked_resource_types=image,media
+      if (query.blocked_resource_types) {
+        console.log(query.blocked_resource_types);
+        const blockedResourceTypes= query.blocked_resource_types
+          .split(',');
+
+        if (blockedResourceTypes.includes(request.resourceType())) {
+          return request.abort();
+        }
+      }
+
       if (query.triggered_requests) {
         triggeredRequests.push({
           type: request.resourceType(),

--- a/src/Clusteer.php
+++ b/src/Clusteer.php
@@ -118,6 +118,17 @@ class Clusteer
     }
 
     /**
+     * Set the resource types to block.
+     *
+     * @param  array  $types
+     * @return $this
+     */
+    public function blockResourceTypes(array $types)
+    {
+        return $this->setParameter('blocked_resource_types', implode(',', $types));
+    }
+
+    /**
      * Set the timeout.
      *
      * @param  int  $seconds

--- a/tests/CrawlingTest.php
+++ b/tests/CrawlingTest.php
@@ -75,6 +75,25 @@ class CrawlingTest extends TestCase
         }
     }
 
+    public function test_block_resource_types()
+    {
+        $blocked_types = [
+            'image',
+        ];
+
+        $clusteer = Clusteer::to('https://renoki.org')
+            ->blockResourceTypes($blocked_types)
+            ->waitUntilAllRequestsFinish()
+            ->withTriggeredRequests()
+            ->get();
+
+        foreach ($clusteer->getTriggeredRequests() as $request) {
+            $this->assertFalse(
+                (bool) in_array($request['type'], $blocked_types)
+            );
+        }
+    }
+
     public function test_cookies()
     {
         $this->markTestIncomplete(


### PR DESCRIPTION
This PR adds the ability to block a request by it's resource type.
You can find more about requests resource types here https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#httprequestresourcetype

The example below will now block every request with the resource type of image.
```php
$clusteer = Clusteer::to('https://renoki.org')
     ->blockResourceTypes(['image'])
     ->waitUntilAllRequestsFinish()
     ->withTriggeredRequests()
     ->get();
```